### PR TITLE
fix(page structure): rearranges page sections

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/App.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/App.tsx
@@ -74,13 +74,9 @@ export class App extends React.Component<AppProps> {
         const Sidebar = <PageSidebar nav={<PageNav/>} />;
 
         return (
-            <span style={{ height: '100%'}}>
                 <Page header={Header} sidebar={Sidebar} isManagedSidebar>
-                    <PageSection>
-                        {makeRoutes()}
-                    </PageSection>
+                    {makeRoutes()}
                 </Page>
-            </span>
         );
     }
 };

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/ContentPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/ContentPage.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react';
-import {Button, Grid, GridItem, Title, Tooltip, Card, CardBody, Stack, StackItem} from '@patternfly/react-core';
+import {Button, Grid, GridItem, Text, Title, Tooltip, Card, CardBody, PageSection, TextContent, PageSectionVariants, SplitItem, Split} from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
 
 import {Msg} from '../widgets/Msg';
@@ -39,35 +39,46 @@ export class ContentPage extends React.Component<ContentPageProps> {
 
     public render(): React.ReactNode {
         return (
-            <React.Fragment>
-                <ContentAlert/>
-                <Stack hasGutter>
-                    <StackItem>
-                        <Card>
-                            <CardBody>
-                                <Grid>
-                                    <GridItem span={11}><Title headingLevel='h1' size='2xl'><strong><Msg msgKey={this.props.title}/></strong></Title></GridItem>
-                                    {this.props.onRefresh &&
-                                        <GridItem span={1}>
-                                            <Tooltip content={<Msg msgKey='refreshPage'/>}>
-                                                <Button aria-describedby="refresh page" id='refresh-page' variant='link' onClick={this.props.onRefresh} icon={<SyncAltIcon />}>
-                                                    Refresh
-                                                </Button>
-                                            </Tooltip>
-                                        </GridItem>
-                                    }
-                                    {this.props.introMessage && <GridItem span={12}> <Msg msgKey={this.props.introMessage}/></GridItem>}
-                                </Grid>
-                            </CardBody>
-                        </Card>
-                    </StackItem>
-                    <StackItem>
-                        <section className="pf-m-no-padding-mobile">
-                            {this.props.children}
-                        </section>
-                    </StackItem>
-                </Stack>
-            </React.Fragment>
+          <React.Fragment>
+            <ContentAlert />
+
+            <PageSection variant={PageSectionVariants.light}>
+              <Split>
+                <SplitItem isFilled>
+                  <TextContent>
+                    <Title headingLevel="h1" size="2xl">
+                      <Msg msgKey={this.props.title} />
+                    </Title>
+                    {this.props.introMessage && (
+                      <Text component="p">
+                        <Msg msgKey={this.props.introMessage} />
+                      </Text>
+                    )}
+                  </TextContent>
+                </SplitItem>
+                {this.props.onRefresh && (
+                  <SplitItem>
+                    <Tooltip content={<Msg msgKey="refreshPage" />}>
+                      <Button
+                        aria-describedby="refresh page"
+                        id="refresh-page"
+                        variant="link"
+                        onClick={this.props.onRefresh}
+                        icon={<SyncAltIcon />}
+                      >
+                        Refresh
+                      </Button>
+                    </Tooltip>
+                  </SplitItem>
+                )}
+              </Split>
+            </PageSection>
+            {/* TODO: this might be better left here, but down the road you'd probably want a parameter for variant and whether there's padding or not */}
+            {/* If so, the page sections in the children should be removed */}
+            {/* <PageSection isFilled variant={PageSectionVariants.light}> */}
+                {this.props.children}
+            {/* </PageSection> */}
+          </React.Fragment>
         );
     }
 };

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/account-page/AccountPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/account-page/AccountPage.tsx
@@ -22,11 +22,11 @@ import { ActionGroup,
          Grid, 
          GridItem, 
          ExpandableSection, 
-         Card, 
-         CardBody,
          HelperText,
          HelperTextItem,
-         ValidatedOptions
+         ValidatedOptions,
+         PageSection,
+         PageSectionVariants
        } from '@patternfly/react-core';
 
 import { HttpResponse } from '../../account-service/account.service';
@@ -157,137 +157,188 @@ export class AccountPage extends React.Component<AccountPageProps, AccountPageSt
     public render(): React.ReactNode {
         const fields: FormFields = this.state.formFields;
         return (
-            <ContentPage title="personalInfoHtmlTitle"
-                introMessage="personalSubMessage">
-                <Card>
-                    <CardBody>
-                        <Form isHorizontal onSubmit={event => this.handleSubmit(event)}>
-                            {!this.isRegistrationEmailAsUsername &&
-                            <FormGroup
-                                label={Msg.localize('username')}
-                                isRequired
-                                fieldId="user-name"
-                                helperTextInvalid={this.state.errors.username}
-                                validated={this.state.errors.username !== '' ? ValidatedOptions.error : ValidatedOptions.default}
-                            >
-                                {this.isEditUserNameAllowed && <this.UsernameInput />}
-                                {!this.isEditUserNameAllowed && <this.RestrictedUsernameInput />}
-                            </FormGroup>
-                            }
-                            <FormGroup
-                                label={Msg.localize('email')}
-                                isRequired
-                                fieldId="email-address"
-                                helperTextInvalid={this.state.errors.email}
-                                validated={this.state.errors.email !== '' ? ValidatedOptions.error : ValidatedOptions.default}
-                            >
-                                <TextInput
-                                    isRequired
-                                    type="email"
-                                    id="email-address"
-                                    name="email"
-                                    maxLength={254}
-                                    value={fields.email}
-                                    onChange={this.handleChange}
-                                    validated={this.state.errors.email !== '' ? ValidatedOptions.error : ValidatedOptions.default}
-                                >
-                                </TextInput>
-                            </FormGroup>
-                            <FormGroup
-                                label={Msg.localize('firstName')}
-                                isRequired
-                                fieldId="first-name"
-                                helperTextInvalid={this.state.errors.firstName}
-                                validated={this.state.errors.firstName !== '' ? ValidatedOptions.error : ValidatedOptions.default}
-                            >
-                                <TextInput
-                                    isRequired
-                                    type="text"
-                                    id="first-name"
-                                    name="firstName"
-                                    maxLength={254}
-                                    value={fields.firstName}
-                                    onChange={this.handleChange}
-                                    validated={this.state.errors.firstName !== '' ? ValidatedOptions.error : ValidatedOptions.default}
-                                >
-                                </TextInput>
-                            </FormGroup>
-                            <FormGroup
-                                label={Msg.localize('lastName')}
-                                isRequired
-                                fieldId="last-name"
-                                helperTextInvalid={this.state.errors.lastName}
-                                validated={this.state.errors.lastName !== '' ? ValidatedOptions.error : ValidatedOptions.default}
-                            >
-                                <TextInput
-                                    isRequired
-                                    type="text"
-                                    id="last-name"
-                                    name="lastName"
-                                    maxLength={254}
-                                    value={fields.lastName}
-                                    onChange={this.handleChange}
-                                    validated={this.state.errors.lastName !== '' ? ValidatedOptions.error : ValidatedOptions.default}
-                                    >
-                                </TextInput>
-                            </FormGroup>
-                            {features.isInternationalizationEnabled && <FormGroup
-                                label={Msg.localize('selectLocale')}
-                                isRequired
-                                fieldId="locale"
-                            >
-                                <LocaleSelector id="locale-selector"
-                                    value={fields.attributes!.locale || ''}
-                                    onChange={value => this.setState({
-                                        errors: this.state.errors,
-                                        formFields: { ...this.state.formFields, attributes: { ...this.state.formFields.attributes, locale: [value] }}
-                    })}
-                                />
-                            </FormGroup>}
-                            <ActionGroup>
-                                <Button
-                                    type="submit"
-                                    id="save-btn"
-                                    variant="primary"
-                                    isDisabled={Object.values(this.state.errors).filter(e => e !== '').length !== 0}
-                                >
-                                    <Msg msgKey="doSave" />
-                                </Button>
-                                <Button
-                                    id="cancel-btn"
-                                    variant="secondary"
-                                    onClick={this.handleCancel}
-                                >
-                                    <Msg msgKey="doCancel" />
-                                </Button>
-                            </ActionGroup>
-                        </Form>
+        <ContentPage
+            title="personalInfoHtmlTitle"
+            introMessage="personalSubMessage"
+            >
+          <PageSection isFilled variant={PageSectionVariants.light}>
+              <Form
+                isHorizontal
+                onSubmit={(event) => this.handleSubmit(event)}
+                isWidthLimited
+              >
+                {!this.isRegistrationEmailAsUsername && (
+                  <FormGroup
+                    label={Msg.localize("username")}
+                    isRequired
+                    fieldId="user-name"
+                    helperTextInvalid={this.state.errors.username}
+                    validated={
+                      this.state.errors.username !== ""
+                        ? ValidatedOptions.error
+                        : ValidatedOptions.default
+                    }
+                  >
+                    {this.isEditUserNameAllowed && <this.UsernameInput />}
+                    {!this.isEditUserNameAllowed && (
+                      <this.RestrictedUsernameInput />
+                    )}
+                  </FormGroup>
+                )}
+                <FormGroup
+                  label={Msg.localize("email")}
+                  isRequired
+                  fieldId="email-address"
+                  helperTextInvalid={this.state.errors.email}
+                  validated={
+                    this.state.errors.email !== ""
+                      ? ValidatedOptions.error
+                      : ValidatedOptions.default
+                  }
+                >
+                  <TextInput
+                    isRequired
+                    type="email"
+                    id="email-address"
+                    name="email"
+                    maxLength={254}
+                    value={fields.email}
+                    onChange={this.handleChange}
+                    validated={
+                      this.state.errors.email !== ""
+                        ? ValidatedOptions.error
+                        : ValidatedOptions.default
+                    }
+                  ></TextInput>
+                </FormGroup>
+                <FormGroup
+                  label={Msg.localize("firstName")}
+                  isRequired
+                  fieldId="first-name"
+                  helperTextInvalid={this.state.errors.firstName}
+                  validated={
+                    this.state.errors.firstName !== ""
+                      ? ValidatedOptions.error
+                      : ValidatedOptions.default
+                  }
+                >
+                  <TextInput
+                    isRequired
+                    type="text"
+                    id="first-name"
+                    name="firstName"
+                    maxLength={254}
+                    value={fields.firstName}
+                    onChange={this.handleChange}
+                    validated={
+                      this.state.errors.firstName !== ""
+                        ? ValidatedOptions.error
+                        : ValidatedOptions.default
+                    }
+                  ></TextInput>
+                </FormGroup>
+                <FormGroup
+                  label={Msg.localize("lastName")}
+                  isRequired
+                  fieldId="last-name"
+                  helperTextInvalid={this.state.errors.lastName}
+                  validated={
+                    this.state.errors.lastName !== ""
+                      ? ValidatedOptions.error
+                      : ValidatedOptions.default
+                  }
+                >
+                  <TextInput
+                    isRequired
+                    type="text"
+                    id="last-name"
+                    name="lastName"
+                    maxLength={254}
+                    value={fields.lastName}
+                    onChange={this.handleChange}
+                    validated={
+                      this.state.errors.lastName !== ""
+                        ? ValidatedOptions.error
+                        : ValidatedOptions.default
+                    }
+                  ></TextInput>
+                </FormGroup>
+                {features.isInternationalizationEnabled && (
+                  <FormGroup
+                    label={Msg.localize("selectLocale")}
+                    isRequired
+                    fieldId="locale"
+                  >
+                    <LocaleSelector
+                      id="locale-selector"
+                      value={fields.attributes!.locale || ""}
+                      onChange={(value) =>
+                        this.setState({
+                          errors: this.state.errors,
+                          formFields: {
+                            ...this.state.formFields,
+                            attributes: {
+                              ...this.state.formFields.attributes,
+                              locale: [value],
+                            },
+                          },
+                        })
+                      }
+                    />
+                  </FormGroup>
+                )}
+                <ActionGroup>
+                  <Button
+                    type="submit"
+                    id="save-btn"
+                    variant="primary"
+                    isDisabled={
+                      Object.values(this.state.errors).filter((e) => e !== "")
+                        .length !== 0
+                    }
+                  >
+                    <Msg msgKey="doSave" />
+                  </Button>
+                  <Button
+                    id="cancel-btn"
+                    variant="secondary"
+                    onClick={this.handleCancel}
+                  >
+                    <Msg msgKey="doCancel" />
+                  </Button>
+                </ActionGroup>
+              </Form>
 
-                        { this.isDeleteAccountAllowed && 
-                        <div id="delete-account" style={{marginTop:"30px"}}>
-                            <ExpandableSection toggleText="Delete Account">
-                                <Grid hasGutter>
-                                    <GridItem span={6}>
-                                        <p>
-                                            <Msg msgKey="deleteAccountWarning" />
-                                        </p>
-                                    </GridItem>
-                                    <GridItem span={4}>
-                                        <KeycloakContext.Consumer>
-                                            { (keycloak: KeycloakService) => (
-                                                <Button id="delete-account-btn" variant="danger" onClick={() => this.handleDelete(keycloak)} className="delete-button"><Msg msgKey="doDelete" /></Button>
-                                            )}
-                                        </KeycloakContext.Consumer>
-                                    </GridItem>
-                                    <GridItem span={2}>
-                                    </GridItem>
-                                </Grid>
-
-                            </ExpandableSection> 
-                        </div>}
-                    </CardBody>
-                </Card>
-            </ContentPage>
+              {this.isDeleteAccountAllowed && (
+                <div id="delete-account" style={{ marginTop: "30px" }}>
+                  <ExpandableSection toggleText="Delete Account">
+                    <Grid hasGutter>
+                      <GridItem span={6}>
+                        <p>
+                          <Msg msgKey="deleteAccountWarning" />
+                        </p>
+                      </GridItem>
+                      <GridItem span={4}>
+                        <KeycloakContext.Consumer>
+                          {(keycloak: KeycloakService) => (
+                            <Button
+                              id="delete-account-btn"
+                              variant="danger"
+                              onClick={() => this.handleDelete(keycloak)}
+                              className="delete-button"
+                            >
+                              <Msg msgKey="doDelete" />
+                            </Button>
+                          )}
+                        </KeycloakContext.Consumer>
+                      </GridItem>
+                      <GridItem span={2}></GridItem>
+                    </Grid>
+                  </ExpandableSection>
+                </div>
+              )}
+           </PageSection>
+        </ContentPage>
         );
     }
 

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/signingin-page/SigningInPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/signingin-page/SigningInPage.tsx
@@ -35,7 +35,8 @@ import {
         DropdownPosition,
         KebabToggle,
         Card,
-        CardTitle
+        CardTitle,
+        PageSection
     } from '@patternfly/react-core';
 
 import {AIACommand} from '../../util/AIACommand';
@@ -146,9 +147,11 @@ class SigningInPage extends React.Component<SigningInPageProps, SigningInPageSta
         return (
           <ContentPage title="signingIn"
                    introMessage="signingInSubMessage">
-              <Stack hasGutter>
-                  {this.renderCategories()}
-              </Stack>
+              <PageSection isFilled>
+                  <Stack hasGutter>
+                    {this.renderCategories()}
+                </Stack>
+              </PageSection>
           </ContentPage>
         );
     }


### PR DESCRIPTION
This tries to clear up some things in the overall page structure that are causing problems. 
- there were nested page sections, which messes up the indentation, so you don't want those.
- I removed some extra spans and divs that aren't needed
- See the comment in ContentPage.tsx about where to put the `<PageSection>`
- I did a few more adjustments to the AccountPage like removing the cards and limiting the width of the input fields.
